### PR TITLE
append log format name to {proxy,admin}_access_log if required

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,9 +47,6 @@ kong_upstream_keepalive:       60
 kong_server_tokens:            "on"
 kong_latency_tokens:           "on"
 
-# NOTE: Remember to set kong_proxy_access_log to:
-#       - "logs/access.log custom" if kong_nginx_custom_log_fields not an empty list
-#       - "logs/access.log custom_json" if kong_nginx_json_log_format_enable is true
 kong_nginx_custom_log_fields: []
 kong_nginx_json_log_format_enable: false
 

--- a/tasks/server-0.10.x.yml
+++ b/tasks/server-0.10.x.yml
@@ -15,6 +15,13 @@
     - Validate kong config
     - Restart kong
 
+# "Reload kong" handler sometimes fails for instance when access_log config
+# This is an edge case when custom log format is configured and name of log format
+# appended to proxy_access_log property value ("logs/access.log"). Unfortunately,
+# "kong reload" command does not recompile nginx-kong.conf as expected before
+# reloading nginx. So the outdated nginx-kong.conf fails nginx config validation
+# and nginx errors out.
+# So it is safer to Restart
 - name: Create kong custom nginx config file | v0.10.x or later
   template: 
     src:  custom-nginx.template.j2
@@ -24,7 +31,7 @@
     mode:  0644
   notify: 
     - Validate kong config
-    - Reload kong
+    - Restart kong
 
 - name: Check kong health status | v0.10.x or later
   shell: kong health || true

--- a/templates/0.10.x-kong.conf.j2
+++ b/templates/0.10.x-kong.conf.j2
@@ -36,6 +36,11 @@ log_level = {{ kong_log_level }}
 # Note: See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list
 # of accepted values.
 
+{% if kong_nginx_json_log_format_enable|default(false) and not kong_proxy_access_log|match('.*custom_json$') %}
+{% set kong_proxy_access_log = kong_proxy_access_log + ' custom_json' %}
+{% elif kong_nginx_custom_log_fields|default([]) and not kong_proxy_access_log|match('.*custom$') %}
+{% set kong_proxy_access_log = kong_proxy_access_log + ' custom' %}
+{% endif %}
 proxy_access_log = {{ kong_proxy_access_log }}
 #proxy_access_log = logs/access.log       # Path for proxy port request access
                                           # logs. Set this value to `off` to
@@ -50,6 +55,11 @@ proxy_error_log = {{ kong_proxy_error_log }}
                                           # adjusted by the `log_level`
                                           # directive.
 
+{% if kong_nginx_json_log_format_enable|default(false) and not kong_admin_access_log|match('.*custom_json$') %}
+{% set kong_admin_access_log = kong_admin_access_log + ' custom_json' %}
+{% elif kong_nginx_custom_log_fields|default([]) and not kong_admin_access_log|match('.*custom$') %}
+{% set kong_admin_access_log = kong_admin_access_log + ' custom' %}
+{% endif %}
 admin_access_log = {{ kong_admin_access_log }}
 #admin_access_log = logs/admin_access.log # Path for Admin API request access
                                           # logs. Set this value to `off` to

--- a/test/integration/node0/default.yml
+++ b/test/integration/node0/default.yml
@@ -49,8 +49,6 @@
       "X-Forwarded-Prefix": '$http_x_forwarded_prefix'
     kong_nginx_custom_log_fields: [ realip_remote_addr, http_x_forwarded_prefix, http_x_forwarded_for, http_x_forwarded_proto ]
     kong_nginx_json_log_format_enable: true
-    kong_proxy_access_log:         "logs/access.log custom_json"
-    kong_admin_access_log:         "logs/access.log custom_json"
 
   pre_tasks:
     - name: Set kong host | RedHat


### PR DESCRIPTION
When custom log format is required, this change appends the appropriate log format name to `proxy_access_log` and `admin_access_log` properties.