### PR TITLE
BAU: Stop kong re-downloading deb on every run

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -10,7 +10,7 @@
 
 # Debian
 - name: Download kong deb package | Debian
-  get_url: url="{{ kong_deb_pkg_url }}" dest=/var/tmp validate_certs=no
+  get_url: url="{{ kong_deb_pkg_url }}" dest=/var/tmp validate_certs=no force=no
   when: ansible_os_family|lower == 'debian'
 
 - name: Install kong prerequisites (Debian/Ubuntu only)


### PR DESCRIPTION
At present, the deb download occasionally fails, stopping the infra
pipeline.

The debs are downloaded to /var/tmp and have the patch version in the
filename, so there is no need to re-download the deb on each run.

By adding 'force=no', we stop get_url from downloading if the file
already exists at destination - see
http://docs.ansible.com/ansible/latest/get_url_module.html and
https://github.com/ansible/ansible/issues/2416 for detail