### PR TITLE
fix unable to update existing plugin

### DIFF
--- a/templates/matched_plugin_id.j2
+++ b/templates/matched_plugin_id.j2
@@ -14,7 +14,7 @@
 {% set consumer_id = consumer.json.id %}
 {% endif %}
 {# Compare values #}
-{% if name == p.name and service_id == p_service_id and consumer_id == p_consumer_id %}
+{% if ( (name == p.name and service_id == p_service_id) or (name == p.name and consumer_id == p_consumer_id) ) %}
 {{ p.id }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## What's New in this PR

- Fix `plugin_exists` variable always False in `ansible-kong/tasks/plugin_add.yml` when specifying only service_id and plugin_name
resolve https://github.com/wunzeco/ansible-kong/issues/16
```
    - role: ansible-kong
      kong_task: plugin
      kong_plugin_config:
        name: cors
        service: profile-users-stats
```
# update
i just realized here i think its related to kong pagination
```
- name: Get list of plugin objects configured in kong
  uri:
    url: "{{ kong_admin_api_url|default('http://localhost:8001') }}/plugins"
  register: plugins
```
the plugins var contain only the 100 first result