### PR TITLE
Query string instead of body.

### DIFF
--- a/tasks/plugin.yml
+++ b/tasks/plugin.yml
@@ -11,8 +11,7 @@
 
 - name: Get list of plugin objects configured in kong
   uri:
-    url: "{{ kong_admin_api_url|default('http://localhost:8001') }}/plugins"
-    body: "size=1000"
+    url: "{{ kong_admin_api_url|default('http://localhost:8001') }}/plugins?size=1000"
   register: plugins
 
 #- debug: var=plugins


### PR DESCRIPTION
## Summary ?

Task fails when specifying size in body.

```
TASK [ansible-kong : Get list of plugin objects configured in kong] ****************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "connection": "close", "content": "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n<html><head>\n<meta type=\"copyright\" content=\"Copyright (C) 1996-2015 The Squid Software Foundation and contributors\">\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n<title>ERROR: The requested URL could not be retrieved</title>\n<style type=\"text/css\"><!-- \n /*\n * Copyright (C) 1996-2015 The Squid Software Foundation and contributors\n *\n * Squid software is distributed under GPLv2+ license and includes\n * contributions from numerous individuals and organizations.\n * Please see the COPYING and CONTRIBUTORS files for details.\n */\n\n/*\n Stylesheet for Squid Error pages\n Adapted from design by Free CSS Templates\n http://www.freecsstemplates.org\n Released for free under a Creative Commons Attribution 2.5 License\n*/\n\n/* Page basics */\n* {\n\tfont-family: verdana, sans-serif;\n}\n\nhtml body {\n\tmargin: 0;\n\tpadding: 0;\n\tbackground: #efefef;\n\tfont-size: 12px;\n\tcolor: #1e1e1e;\n}\n\n/* Page displayed title area */\n#titles {\n\tmargin-left: 15px;\n\tpadding: 10px;\n\tpadding-left: 100px;\n\tbackground: url('/squid-internal-static/icons/SN.png') no-repeat left;\n}\n\n/* initial title */\n#titles h1 {\n\tcolor: #000000;\n}\n#titles h2 {\n\tcolor: #000000;\n}\n\n/* special event: FTP success page titles */\n#titles ftpsuccess {\n\tbackground-color:#00ff00;\n\twidth:100%;\n}\n\n/* Page displayed body content area */\n#content {\n\tpadding: 10px;\n\tbackground: #ffffff;\n}\n\n/* General text */\np {\n}\n\n/* error brief description */\n#error p {\n}\n\n/* some data which may have caused the problem */\n#data {\n}\n\n/* the error message received from the system or other software */\n#sysmsg {\n}\n\npre {\n    font-family:sans-serif;\n}\n\n/* special event: FTP / Gopher directory listing */\n#dirmsg {\n    font-family: courier;\n    color: black;\n    font-size: 10pt;\n}\n#dirlisting {\n    margin-left: 2%;\n    margin-right: 2%;\n}\n#dirlisting tr.entry td.icon,td.filename,td.size,td.date {\n    border-bottom: groove;\n}\n#dirlisting td.size {\n    width: 50px;\n    text-align: right;\n    padding-right: 5px;\n}\n\n/* horizontal lines */\nhr {\n\tmargin: 0;\n}\n\n/* page displayed footer area */\n#footer {\n\tfont-size: 9px;\n\tpadding-left: 10px;\n}\n\n\nbody\n:lang(fa) { direction: rtl; font-size: 100%; font-family: Tahoma, Roya, sans-serif; float: right; }\n:lang(he) { direction: rtl; }\n --></style>\n</head><body id=ERR_INVALID_REQ>\n<div id=\"titles\">\n<h1>ERROR</h1>\n<h2>The requested URL could not be retrieved</h2>\n</div>\n<hr>\n\n<div id=\"content\">\n<p><b>Invalid Request</b> error was encountered while trying to process the request:</p>\n\n<blockquote id=\"data\">\n<pre>GET /plugins HTTP/1.1\nAccept-Encoding: identity\r\nContent-Length: 9\r\nContent-Type: application/x-www-form-urlencoded\r\nConnection: close\r\nUser-Agent: ansible-httpget\r\nHost: stage-kong-13-master.xxxx.co:8001\r\n</pre>\n</blockquote>\n\n<p>Some possible problems are:</p>\n<ul>\n<li id=\"missing-method\"><p>Missing or unknown request method.</p></li>\n<li id=\"missing-url\"><p>Missing URL.</p></li>\n<li id=\"missing-protocol\"><p>Missing HTTP Identifier (HTTP/1.0).</p></li>\n<li><p>Request is too large.</p></li>\n<li><p>Content-Length missing for POST or PUT requests.</p></li>\n<li><p>Illegal character in hostname; underscores are not allowed.</p></li>\n<li><p>HTTP/1.1 <q>Expect:</q> feature is being asked from an HTTP/1.0 software.</p></li>\n</ul>\n\n<p>Your cache administrator is <a href=\"mailto:webmaster?subject=CacheErrorInfo%20-%20ERR_INVALID_REQ&amp;body=CacheHost%3A%20packer-5a802b6f-987a-8190-ee48-0de9ff88de6b%0D%0AErrPage%3A%20ERR_INVALID_REQ%0D%0AErr%3A%20%5Bnone%5D%0D%0ATimeStamp%3A%20Sun,%2003%20Jun%202018%2016%3A12%3A33%20GMT%0D%0A%0D%0AClientIP%3A%2010.1.4.39%0D%0A%0D%0AHTTP%20Request%3A%0D%0AGET%20%2Fplugins%20HTTP%2F1.1%0AAccept-Encoding%3A%20identity%0D%0AContent-Length%3A%209%0D%0AContent-Type%3A%20application%2Fx-www-form-urlencoded%0D%0AConnection%3A%20close%0D%0AUser-Agent%3A%20ansible-httpget%0D%0AHost%3A%20stage-kong-13-master.xxxx.co%3A8001%0D%0A%0D%0A%0D%0A\">webmaster</a>.</p>\n<br>\n</div>\n\n<script language=\"javascript\">\nif ('GET' != '[unknown method]') document.getElementById('missing-method').style.display = 'none';\nif ('http://stage-kong-13-master.xxxx.co:8001/plugins' != '[no URL]') document.getElementById('missing-url').style.display = 'none';\nif ('http' != '[unknown protocol]') document.getElementById('missing-protocol').style.display = 'none';\n</script>\n\n<hr>\n<div id=\"footer\">\n<p>Generated Sun, 03 Jun 2018 16:12:33 GMT by packer-5a802b6f-987a-8190-ee48-0de9ff88de6b (squid/3.5.12)</p>\n<!-- ERR_INVALID_REQ -->\n</div>\n</body></html>\n", "content_language": "en", "content_length": "4571", "content_type": "text/html;charset=utf-8", "date": "Sun, 03 Jun 2018 16:12:33 GMT", "failed": true, "mime_version": "1.0", "msg": "Status code was not [200]: HTTP Error 411: Length Required", "redirected": false, "server": "squid/3.5.12", "status": 411, "url": "http://stage-kong-13-master.xxxx.co:8001/plugins", "vary": "Accept-Language", "via": "1.1 packer-5a802b6f-987a-8190-ee48-0de9ff88de6b (squid/3.5.12)", "x_cache": "MISS from packer-5a802b6f-987a-8190-ee48-0de9ff88de6b", "x_cache_lookup": "NONE from packer-5a802b6f-987a-8190-ee48-0de9ff88de6b:3128", "x_squid_error": "ERR_INVALID_REQ 0"}
```