### PR TITLE
Kong 1.0 compatibility

### DIFF
--- a/tasks/route_add.yml
+++ b/tasks/route_add.yml
@@ -15,7 +15,7 @@
 - name: Sanitize kong_route_config dict
   set_fact:
     kong_route_config_new: "{{ kong_route_config_new|combine({item.key: item.value}) }}"
-  when: item.key not in ['name']
+  #when: item.key not in ['name']
   with_dict: "{{ kong_route_config }}"
 
 - name: Include service id in route obj config

--- a/templates/matched_plugin_id.j2
+++ b/templates/matched_plugin_id.j2
@@ -7,9 +7,9 @@
 {% set service_id  = '' %}
 {% set route_id    = plugin_route_id %}
 {% set consumer_id = '' %}
-{% set p_service_id  = p.service_id|default('') %}
-{% set p_route_id    = p.route_id|default('') %}
-{% set p_consumer_id = p.consumer_id|default('') %}
+{% set p_service_id  = p.service.id|default('') %}
+{% set p_route_id    = p.route.id|default('') %}
+{% set p_consumer_id = p.consumer.id|default('') %}
 {% if service.status|default(false) == 200 %}
 {% set service_id = service.json.id %}
 {% endif %}

--- a/templates/plugin_obj.j2
+++ b/templates/plugin_obj.j2
@@ -9,12 +9,12 @@
 {% endif %}
 {% endfor %}
 {% if service.status|default(false) == 200 %}
-{% if plugin_obj.update({'service_id': service.json.id}) %}{% endif %}
+{% if plugin_obj.update({'service': {'id':service.json.id}}) %}{% endif %}
 {% endif %}
 {% if plugin_route_id|default(false) %}
-{% if plugin_obj.update({'route_id': plugin_route_id}) %}{% endif %}
+{% if plugin_obj.update({'route': {'id':plugin_route_id}}) %}{% endif %}
 {% endif %}
 {% if consumer.status|default(false) == 200 %}
-{% if plugin_obj.update({'consumer_id': consumer.json.id}) %}{% endif %}
+{% if plugin_obj.update({'consumer': {'id': consumer.json.id}) %}{% endif %}
 {% endif %}
 {{ plugin_obj|to_nice_json }}


### PR DESCRIPTION
First step to have it compatible to kong 1.0
WARNING: it is not backward compatible as the admin API changed.
One part is to adapt the templates around plugins (matching and objects).
The other part is to create a route name in kong as it is now possible.

Additional work can be done to benefit from the routes names to simplify the forced use of routes id when there was no routes name